### PR TITLE
add MeSH identifiers endpoint

### DIFF
--- a/inference/README.md
+++ b/inference/README.md
@@ -11,5 +11,6 @@ Sanitising and linking/disambiguating concepts to their counterparts in LCSH, Me
 Then run with docker:
 
 ```
-docker build -t concepts_inference .; docker run concepts_inference
+docker build -t concepts_inference .
+docker run -v config.json:/config.json -p 80:80 concepts_inference
 ```

--- a/inference/app/main.py
+++ b/inference/app/main.py
@@ -38,7 +38,7 @@ def mesh_endpoint(mesh_id: str):
         logger.error(error_string)
         raise HTTPException(status_code=404, detail=error_string)
 
-    logger.info(f"aggregated concept data for lc_names ID: {mesh_id}")
+    logger.info(f"aggregated concept data for MeSH ID: {mesh_id}")
     return response
 
 

--- a/inference/app/main.py
+++ b/inference/app/main.py
@@ -3,7 +3,7 @@ import logging
 
 from fastapi import FastAPI, HTTPException
 
-from .src.aggregate import aggregate_lc_names_data
+from .src.aggregate import aggregate_lc_names_data, aggregate_mesh_data
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +17,7 @@ logger.info("API started, awaiting requests")
 
 
 @app.get("/lc-names/{lc_names_id}")
-def main(lc_names_id: str):
+def lc_names_endpoint(lc_names_id: str):
     try:
         response = aggregate_lc_names_data(lc_names_id)
     except ValueError as e:
@@ -26,6 +26,19 @@ def main(lc_names_id: str):
         raise HTTPException(status_code=404, detail=error_string)
 
     logger.info(f"aggregated concept data for lc_names ID: {lc_names_id}")
+    return response
+
+
+@app.get("/mesh/{mesh_id}")
+def mesh_endpoint(mesh_id: str):
+    try:
+        response = aggregate_mesh_data(mesh_id)
+    except ValueError as e:
+        error_string = str(e)
+        logger.error(error_string)
+        raise HTTPException(status_code=404, detail=error_string)
+
+    logger.info(f"aggregated concept data for lc_names ID: {mesh_id}")
     return response
 
 

--- a/inference/app/src/aggregate.py
+++ b/inference/app/src/aggregate.py
@@ -29,9 +29,9 @@ def aggregate_lc_names_data(lc_names_id):
         log.info(f"Got data from wikidata for ID: {wikidata_id}")
 
         alt_source_ids = wikidata_id_to_alt_source_ids(wikidata_id)
-        if alt_source_ids['lc_names']:
-            lc_names_id = alt_source_ids['lc_names']
-            response['exact']['lc_names'] = get_lc_names_data(lc_names_id)
+        if alt_source_ids['mesh']:
+            mesh_id = alt_source_ids['mesh']
+            response['exact']['mesh'] = get_mesh_data(mesh_id)
 
     return response
 

--- a/inference/app/src/aggregate.py
+++ b/inference/app/src/aggregate.py
@@ -11,12 +11,12 @@ log = logging.getLogger(__name__)
 def aggregate_lc_names_data(lc_names_id):
     lc_names_data = get_lc_names_data(lc_names_id)
     log.info(f"Got data from lc_names for ID: {lc_names_id}")
+
     try:
         wikidata_id = lc_names_id_to_wikidata_id(lc_names_id)
         log.info(
             f'Found a link from lc_names ID: {lc_names_id} to wikidata ID: {wikidata_id}'
         )
-
         wikidata_data = get_wikidata_data(wikidata_id)
         log.info(f"Got data from wikidata for ID: {lc_names_id}")
     except ValueError:
@@ -30,19 +30,19 @@ def aggregate_lc_names_data(lc_names_id):
             "lc_names": lc_names_data,
             "wikidata": wikidata_data
         },
-        "inferred": {}  # TODO
+        "inferred": {}
     }
 
 
 def aggregate_mesh_data(mesh_id):
     mesh_data = get_mesh_data(mesh_id)
     log.info(f"Got data from MeSH for ID: {mesh_id}")
+
     try:
         wikidata_id = mesh_id_to_wikidata_id(mesh_id)
         log.info(
             f'Found a link from mesh ID: {mesh_id} to wikidata ID: {wikidata_id}'
         )
-
         wikidata_data = get_wikidata_data(wikidata_id)
         log.info(f"Got data from wikidata for ID: {mesh_id}")
     except ValueError:
@@ -56,5 +56,5 @@ def aggregate_mesh_data(mesh_id):
             "mesh": mesh_data,
             "wikidata": wikidata_data
         },
-        "inferred": {}  # TODO
+        "inferred": {}
     }

--- a/inference/app/src/aggregate.py
+++ b/inference/app/src/aggregate.py
@@ -1,7 +1,8 @@
 import logging
 
 from .exact.lc_names import get_lc_names_data
-from .exact.utils import lc_names_id_to_wikidata_id
+from .exact.mesh import get_mesh_data
+from .exact.utils import lc_names_id_to_wikidata_id, mesh_id_to_wikidata_id
 from .exact.wikidata import get_wikidata_data
 
 log = logging.getLogger(__name__)
@@ -9,7 +10,7 @@ log = logging.getLogger(__name__)
 
 def aggregate_lc_names_data(lc_names_id):
     lc_names_data = get_lc_names_data(lc_names_id)
-    log.info(f"Got lc_names data from lc_names for ID: {lc_names_id}")
+    log.info(f"Got data from lc_names for ID: {lc_names_id}")
     try:
         wikidata_id = lc_names_id_to_wikidata_id(lc_names_id)
         log.info(
@@ -17,7 +18,7 @@ def aggregate_lc_names_data(lc_names_id):
         )
 
         wikidata_data = get_wikidata_data(wikidata_id)
-        log.info(f"Got lc_names data from wikidata for ID: {lc_names_id}")
+        log.info(f"Got data from wikidata for ID: {lc_names_id}")
     except ValueError:
         log.info(
             f"Couldn't find a wikidata record for lc_names ID: {lc_names_id}"
@@ -27,6 +28,32 @@ def aggregate_lc_names_data(lc_names_id):
     return {
         "exact": {
             "lc_names": lc_names_data,
+            "wikidata": wikidata_data
+        },
+        "inferred": {}  # TODO
+    }
+
+
+def aggregate_mesh_data(mesh_id):
+    mesh_data = get_mesh_data(mesh_id)
+    log.info(f"Got data from MeSH for ID: {mesh_id}")
+    try:
+        wikidata_id = mesh_id_to_wikidata_id(mesh_id)
+        log.info(
+            f'Found a link from mesh ID: {mesh_id} to wikidata ID: {wikidata_id}'
+        )
+
+        wikidata_data = get_wikidata_data(wikidata_id)
+        log.info(f"Got data from wikidata for ID: {mesh_id}")
+    except ValueError:
+        log.info(
+            f"Couldn't find a wikidata record for ID: {mesh_id}"
+        )
+        wikidata_data = {}
+
+    return {
+        "exact": {
+            "mesh": mesh_data,
             "wikidata": wikidata_data
         },
         "inferred": {}  # TODO

--- a/inference/app/src/aggregate.py
+++ b/inference/app/src/aggregate.py
@@ -9,7 +9,11 @@ log = logging.getLogger(__name__)
 
 
 def aggregate_lc_names_data(lc_names_id):
-    lc_names_data = get_lc_names_data(lc_names_id)
+    response = {
+        'exact': {},
+        'inferred': {}
+    }
+    response['exact']['lc_names'] = get_lc_names_data(lc_names_id)
     log.info(f"Got data from lc_names for ID: {lc_names_id}")
 
     try:
@@ -17,21 +21,19 @@ def aggregate_lc_names_data(lc_names_id):
         log.info(
             f'Found a link from lc_names ID: {lc_names_id} to wikidata ID: {wikidata_id}'
         )
-        wikidata_data = get_wikidata_data(wikidata_id)
-        log.info(f"Got data from wikidata for ID: {lc_names_id}")
     except ValueError:
-        log.info(
-            f"Couldn't find a wikidata record for lc_names ID: {lc_names_id}"
-        )
-        wikidata_data = {}
+        log.info(f"Couldn't find a wikidata record for ID: {lc_names_id}")
 
-    return {
-        "exact": {
-            "lc_names": lc_names_data,
-            "wikidata": wikidata_data
-        },
-        "inferred": {}
-    }
+    if wikidata_id:
+        response['exact']['wikidata'] = get_wikidata_data(wikidata_id)
+        log.info(f"Got data from wikidata for ID: {wikidata_id}")
+
+        alt_source_ids = wikidata_id_to_alt_source_ids(wikidata_id)
+        if alt_source_ids['lc_names']:
+            lc_names_id = alt_source_ids['lc_names']
+            response['exact']['lc_names'] = get_lc_names_data(lc_names_id)
+
+    return response
 
 
 def aggregate_mesh_data(mesh_id):

--- a/inference/app/src/exact/lc_names.py
+++ b/inference/app/src/exact/lc_names.py
@@ -15,8 +15,7 @@ def get_lc_names_api_response(lc_names_id):
         )
 
 
-def get_lc_names_preferred_label(lc_names_id, api_response=None):
-    api_response = api_response or get_lc_names_api_response(lc_names_id)
+def get_lc_names_preferred_label(api_response):
     preferred_label_id = "http://www.w3.org/2004/02/skos/core#prefLabel"
     preferred_label = None
     for element in api_response:
@@ -25,8 +24,7 @@ def get_lc_names_preferred_label(lc_names_id, api_response=None):
     return preferred_label
 
 
-def get_lc_names_variants(lc_names_id, api_response=None):
-    api_response = api_response or get_lc_names_api_response(lc_names_id)
+def get_lc_names_variants(api_response):
     variant_id = "http://www.loc.gov/mads/rdf/v1#variantLabel"
     variants = [
         element[variant_id][0]["@value"]
@@ -38,8 +36,8 @@ def get_lc_names_variants(lc_names_id, api_response=None):
 
 def get_lc_names_data(lc_names_id):
     api_response = get_lc_names_api_response(lc_names_id)
-    preferred_label = get_lc_names_preferred_label(lc_names_id, api_response)
-    variants = get_lc_names_variants(lc_names_id, api_response)
+    preferred_label = get_lc_names_preferred_label(api_response)
+    variants = get_lc_names_variants(api_response)
     return {
         "id": lc_names_id,
         "title": preferred_label,

--- a/inference/app/src/exact/lc_subjects.py
+++ b/inference/app/src/exact/lc_subjects.py
@@ -1,2 +1,2 @@
-def get_lc_subjects_data(lcsh_id):
+def get_lc_subjects_data(lc_subjects_id):
     return None

--- a/inference/app/src/exact/mesh.py
+++ b/inference/app/src/exact/mesh.py
@@ -38,14 +38,16 @@ def get_mesh_data(mesh_id):
         log.info(f'Couldn\'t find preferred name for ID: {mesh_id}')
         preferred_name = None
 
-    try:
+    if "PreferredConceptScopeNote" in api_response:
         description = api_response["PreferredConceptScopeNote"]
-    except KeyError:
+    elif "scrNote" in api_response:
+        description = api_response["scrNote"]
+    else:
         log.info(f'Couldn\'t find description for ID: {mesh_id}')
-        preferred_name = None
+        description = None
 
     try:
-        variants = api_response["permutatedEntryTerms"]
+        variants = api_response["originalEntryTerms"]
     except KeyError:
         log.info(f'Couldn\'t find variants for ID: {mesh_id}')
         variants = []

--- a/inference/app/src/exact/mesh.py
+++ b/inference/app/src/exact/mesh.py
@@ -1,2 +1,58 @@
+import requests
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def get_mesh_api_response(mesh_id):
+    url = "https://meshb.nlm.nih.gov/api/search/record"
+    params = {
+        "searchInField": "ui",
+        "sort": "",
+        "size": "1",
+        "searchType": "exactMatch",
+        "searchMethod": "FullWord",
+        "q": mesh_id
+    }
+    response = requests.get(url, params)
+    try:
+        generated_response = (
+            response.json()['hits']['hits'][0]['_source']['_generated']
+        )
+    except IndexError:
+        raise ValueError(f'{mesh_id} is not a valid MeSH ID')
+    except KeyError:
+        requested_url = response.url
+        raise ValueError(
+            f"something unexpected happened when calling url: {requested_url}"
+        )
+    return generated_response
+
+
 def get_mesh_data(mesh_id):
-    return None
+    api_response = get_mesh_api_response(mesh_id)
+
+    try:
+        preferred_name = api_response["RecordName"]
+    except KeyError:
+        log.info(f'Couldn\'t find preferred name for ID: {mesh_id}')
+        preferred_name = None
+
+    try:
+        description = api_response["PreferredConceptScopeNote"]
+    except KeyError:
+        log.info(f'Couldn\'t find description for ID: {mesh_id}')
+        preferred_name = None
+
+    try:
+        variants = api_response["permutatedEntryTerms"]
+    except KeyError:
+        log.info(f'Couldn\'t find variants for ID: {mesh_id}')
+        variants = []
+
+    return {
+        "id": mesh_id,
+        "preferred_name": preferred_name,
+        "description": description,
+        "variants": variants
+    }

--- a/inference/app/src/exact/utils.py
+++ b/inference/app/src/exact/utils.py
@@ -3,8 +3,8 @@ import requests
 from .lc_names import get_lc_names_api_response
 
 
-def get_wikidata_id_from_loc(lc_names_id, api_response=None):
-    api_response = api_response or get_lc_names_api_response(lc_names_id)
+def get_wikidata_id_from_loc(lc_names_id):
+    api_response = get_lc_names_api_response(lc_names_id)
 
     wikidata_id = None
     for element in api_response:
@@ -19,34 +19,42 @@ def get_wikidata_id_from_loc(lc_names_id, api_response=None):
     return wikidata_id
 
 
-def get_wikidata_id_from_wikidata(lc_names_id):
+def find_alt_source_id_in_wikidata(alt_source_id):
     response = requests.get(
         url="https://www.wikidata.org/w/api.php",
         params={
             "action": "query",
             "list": "search",
-            "srsearch": lc_names_id,
+            "srsearch": alt_source_id,
             "format": "json"
         }
     ).json()
 
     try:
-        first_result = response["query"]["search"][0]
-        wikidata_id = first_result["title"]
+        wikidata_id = response["query"]["search"][0]["title"]
     except (KeyError, IndexError):
-        raise ValueError(f"Couldn't find '{lc_names_id}' in Wikidata")
-
+        raise ValueError(f"Couldn't find '{alt_source_id}' in Wikidata")
     return wikidata_id
 
 
-def lc_names_id_to_wikidata_id(lc_names_id, api_response=None):
+def lc_names_id_to_wikidata_id(lc_names_id):
     try:
-        wikidata_id = get_wikidata_id_from_loc(lc_names_id, api_response)
+        wikidata_id = get_wikidata_id_from_loc(lc_names_id)
     except ValueError:
         try:
-            wikidata_id = get_wikidata_id_from_wikidata(lc_names_id)
+            wikidata_id = find_alt_source_id_in_wikidata(lc_names_id)
         except ValueError:
             raise ValueError(
                 f"No link found between Library of Congress and Wikidata for ID: {lc_names_id}"
             )
+    return wikidata_id
+
+
+def mesh_id_to_wikidata_id(mesh_id):
+    try:
+        wikidata_id = find_alt_source_id_in_wikidata(mesh_id)
+    except ValueError:
+        raise ValueError(
+            f"No link found between MeSH and Wikidata for ID: {mesh_id}"
+        )
     return wikidata_id

--- a/inference/app/src/exact/utils.py
+++ b/inference/app/src/exact/utils.py
@@ -1,6 +1,7 @@
 import os
 import requests
 from .lc_names import get_lc_names_api_response
+from .wikidata import get_wikidata_api_response
 
 
 def get_wikidata_id_from_loc(lc_names_id):
@@ -58,3 +59,29 @@ def mesh_id_to_wikidata_id(mesh_id):
             f"No link found between MeSH and Wikidata for ID: {mesh_id}"
         )
     return wikidata_id
+
+
+def wikidata_id_to_alt_source_ids(wikidata_id):
+    ids = {
+        'lc_names': None,
+        'lc_subjects': None,
+        'mesh': None
+    }
+    api_response = get_wikidata_api_response(wikidata_id)
+    claims = api_response['claims']
+
+    try:
+        loc_id = claims['P244'][0]["mainsnak"]["datavalue"]["value"]
+        if loc_id.startswith('sh'):
+            ids["lc_subjects"] = loc_id
+        elif loc_id.startswith('n'):
+            ids["lc_names"] = loc_id
+    except KeyError:
+        pass
+
+    try:
+        ids["mesh_id"] = claims['P486'][0]["mainsnak"]["datavalue"]["value"]
+    except KeyError:
+        pass
+
+    return ids

--- a/inference/app/src/exact/wikidata.py
+++ b/inference/app/src/exact/wikidata.py
@@ -4,40 +4,44 @@ import logging
 log = logging.getLogger(__name__)
 
 
-def get_wikidata_data(wikidata_id):
+def get_wikidata_api_response(wikidata_id):
     wikidata_url = f'http://www.wikidata.org/wiki/Special:EntityData/{wikidata_id}.json'
     wikidata_response = requests.get(wikidata_url).json()
-    wikidata_id = list(wikidata_response['entities'].keys())[0]
-    wikidata_record = wikidata_response['entities'][wikidata_id]
+    api_response = wikidata_response['entities'][wikidata_id]
+    return api_response
+
+
+def get_wikidata_data(wikidata_id):
+    api_response = get_wikidata_api_response(wikidata_id)
 
     try:
-        label = wikidata_record['labels']['en']['value']
+        label = api_response['labels']['en']['value']
     except KeyError:
         log.info(f'Couldn\'t find label for ID: {wikidata_id}')
         label = None
 
     try:
-        description = wikidata_record['descriptions']['en']['value']
+        description = api_response['descriptions']['en']['value']
     except KeyError:
         log.info(f'Couldn\'t find description for ID: {wikidata_id}')
         description = None
 
     try:
         aliases = [
-            alias['value'] for alias in wikidata_record['aliases']['en']
+            alias['value'] for alias in api_response['aliases']['en']
         ]
     except KeyError:
         log.info(f'Couldn\'t find aliases for ID: {wikidata_id}')
         aliases = []
 
     try:
-        birth_date = wikidata_record['claims']['P569'][0]['mainsnak']['datavalue']['value']['time']
+        birth_date = api_response['claims']['P569'][0]['mainsnak']['datavalue']['value']['time']
     except KeyError:
         log.info(f'Couldn\'t find birth date for ID: {wikidata_id}')
         birth_date = None
 
     try:
-        death_date = wikidata_record['claims']['P570'][0]['mainsnak']['datavalue']['value']['time']
+        death_date = api_response['claims']['P570'][0]['mainsnak']['datavalue']['value']['time']
     except KeyError:
         log.info(f'Couldn\'t find death date for ID: {wikidata_id}')
         death_date = None


### PR DESCRIPTION
now, hitting `/mesh/D001336` returns

```json
{
    "exact": {
        "mesh": {
            "id": "D001336",
            "preferred_name": "Automobiles",
            "description": "A usually four-wheeled automotive vehicle designed for passenger transportation.",
            "variants": [
                "Automobiles",
                "Cars"
            ]
        },
        "wikidata": {
            "id": "Q1420",
            "title": "car",
            "description": "road vehicle powered by a motor to carry driver and small number of passengers",
            "birth_date": null,
            "death_date": null,
            "variants": [
                "🚗",
                "auto",
                "autocar",
                "motor car",
                "automobile",
                "motorcar"
            ]
        }
    },
    "inferred": {}
}

```